### PR TITLE
perf: only listen to relevant logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-discord-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PM2 Discord Logger",
   "main": "dist/app.js",
   "author": "Derick M. <58572875+TurtIeSocks@users.noreply.github.com>",


### PR DESCRIPTION
Skips listening to log events if those logs aren't configured to be used anyway